### PR TITLE
Add --with-childs option to pg_dump

### DIFF
--- a/doc/src/sgml/ref/pg_dump.sgml
+++ b/doc/src/sgml/ref/pg_dump.sgml
@@ -1173,6 +1173,17 @@ PostgreSQL documentation
      </varlistentry>
 
      <varlistentry>
+      <term><option>--with-childs</option></term>
+      <listitem>
+       <para>
+	Include or exclude from a dump all child and partition tables when a parent
+	table is specified using option <option>-t</option>/<option>--table</option>
+	or <option>-T</option>/<option>--exclude-table</option>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
        <term><option>-?</option></term>
        <term><option>--help</option></term>
        <listitem>

--- a/src/bin/pg_dump/pg_backup.h
+++ b/src/bin/pg_dump/pg_backup.h
@@ -200,6 +200,7 @@ typedef struct _dumpOptions
 
 	int			sequence_data;	/* dump sequence data even in schema-only mode */
 	int			do_nothing;
+	bool			with_childs;
 } DumpOptions;
 
 /*


### PR DESCRIPTION
Used to include or exclude from a dump all child and partition tables when a parent table is specified using option -t/-table or -T/--exclude-table.